### PR TITLE
passing event to handleSelection() callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ A React component that takes the following props:
 #### handleSelection: Function, required
 
 A callback to run when the user makes a selection (i.e. clicks or presses Enter or Space on a menu item).
-It will be passed the value of the selected menu item (as defined in the `items` prop).
+
+It will be passed the value of the selected menu item (as defined in the `items` prop) as the first argument, and the React SyntheticEvent that triggered the selection as the second argument.
 
 While the menu's open/closed-state is handled internally, the selection-state is up to you: do with it what you will.
 

--- a/src/createAriaMenuButton.js
+++ b/src/createAriaMenuButton.js
@@ -114,9 +114,9 @@ export default function createAriaMenuButton(opts={}) {
       }, 0);
     }
 
-    handleSelection(v) {
+    handleSelection(v, e) {
       if (this.props.closeOnSelection) this.closeMenu();
-      this.props.handleSelection(v);
+      this.props.handleSelection(v, e);
     }
 
     handleOverlayClick() {

--- a/test/clicking.js
+++ b/test/clicking.js
@@ -49,7 +49,7 @@ test('when menuItem is clicked', t => {
   u.render(OpenSpyComponent, function() {
     u.eachMenuItemNode(this, (n, i) => {
       clickNode(n);
-      t.ok(spy.calledWith(testItems[i].value),
+      t.ok(spy.calledWithExactly(testItems[i].value, sinon.match.has('nativeEvent')),
         'menuItem ' + i + ' selected');
       t.ok(u.menuIsOpen(this), 'menu is still open');
       spy.reset();

--- a/test/keyboard.js
+++ b/test/keyboard.js
@@ -309,10 +309,10 @@ test('when key is pressed inside menu', t => {
       this.openMenu();
       u.getMenuItemNodes(this).forEach((n, i) => {
         press(n, 'Enter');
-        st.ok(spy.calledWith(testItems[i].value), 'Enter worked');
+        st.ok(spy.calledWithExactly(testItems[i].value, sinon.match.has('nativeEvent')), 'Enter worked');
         spy.reset();
         press(n, ' ');
-        st.ok(spy.calledWith(testItems[i].value), 'Space worked');
+        st.ok(spy.calledWithExactly(testItems[i].value, sinon.match.has('nativeEvent')), 'Space worked');
         spy.reset();
         st.ok(u.menuIsOpen(this), 'menu is still open');
       });


### PR DESCRIPTION
First of all, wanted to start out by saying thank you for this very useful component!

Submitting this PR so that the underlying event that triggers the menu item selection can be accessed by the user via the `handleSelection` callback.

I ran into a case where I had this component nested inside another component that was listening for `mouseDown` events, so I wanted to be able to `stopPropogation` after the menu item was selected so that it would not accidentally trigger the `mouseDown` listener on the container component.

I decided to just pass the React SyntheticEvent in the callback, but I was debating over whether to send that or the underlying `nativeEvent` object. Let me know what you think. Thanks!