### PR TITLE
Make it possible to add an object to value

### DIFF
--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -56,6 +56,7 @@ MenuItem.propTypes = {
     PropTypes.bool,
     PropTypes.number,
     PropTypes.string,
+    PropTypes.object
   ]),
 };
 

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -56,7 +56,7 @@ MenuItem.propTypes = {
     PropTypes.bool,
     PropTypes.number,
     PropTypes.string,
-    PropTypes.object
+    PropTypes.object,
   ]),
 };
 


### PR DESCRIPTION
In our menu we want some of the buttons to eighter navigate to internal or external url's. We pass the url to the MenuItem using the value property, so onSelection can trigger the navigation. The problem is that we use React Router which requires us to either call Router.transitionTo() or window.location depending on if the URL is internal or external. We cant t determine if an url is an internal since the value is just a string. If the value could be an object, we could send { internal:true, url:'http://url' }