### PR TITLE
Support focusGroup options to be passed to wrapper

### DIFF
--- a/lib/Wrapper.js
+++ b/lib/Wrapper.js
@@ -29,11 +29,7 @@ module.exports = React.createClass({
   },
 
   componentWillMount: function() {
-    this.manager = createManager({
-      onSelection: this.props.onSelection,
-      closeOnSelection: this.props.closeOnSelection,
-      id: this.props.id,
-    });
+    this.manager = createManager(this.props);
   },
 
   render: function() {

--- a/lib/createManager.js
+++ b/lib/createManager.js
@@ -2,15 +2,20 @@ var ReactDOM = require('react-dom');
 var createFocusGroup = require('focus-group');
 var externalStateControl = require('./externalStateControl');
 
-var focusGroupOptions = {
-  wrap: true,
-  stringSearch: true,
-};
-
 var protoManager = {
 
   init: function(options) {
     this.options = options || {};
+
+    var focusGroupOptions = this.options;
+
+    if (typeof focusGroupOptions.wrap === 'undefined') {
+      focusGroupOptions.wrap = true;
+    }
+
+    if (typeof focusGroupOptions.stringSearch === 'undefined') {
+      focusGroupOptions.stringSearch = true;
+    }
 
     if (typeof this.options.closeOnSelection === 'undefined') {
       this.options.closeOnSelection = true;

--- a/test/Manager-test.js
+++ b/test/Manager-test.js
@@ -46,6 +46,19 @@ test('Manager initialization', function(t) {
   t.end();
 });
 
+test('Manager initialization with options', function(t) {
+  var m = mockManager({
+    forwardArrows: ['down', 'right'],
+    backArrows: ['up', 'left'],
+  });
+  t.notOk(m.isOpen);
+  t.deepEqual(m.options.forwardArrows, ['down', 'right'], 'pass forwardArrows option');
+  t.deepEqual(m.options.backArrows, ['up', 'left'], 'pass backArrows option');
+  t.deepEqual(m.focusGroup._settings.forwardArrows, ['down', 'right'], 'pass option to focusGroup');
+  t.deepEqual(m.focusGroup._settings.backArrows, ['up', 'left'], 'pass option to focusGroup');
+  t.end();
+});
+
 test('Manager#update', function(t) {
   var m = mockManager();
   m.update();


### PR DESCRIPTION
This way we have some control of focus group from outside. (passing forward/back arrows options for example).

Fixes #44 