### PR TITLE
fixes global not defined in UMD build

### DIFF
--- a/webpack-umd.config.js
+++ b/webpack-umd.config.js
@@ -31,12 +31,10 @@ module.exports = {
   ],
   node: {
     Buffer: false,
-    global: false,
     process: false,
     setImmediate: false,
   },
   plugins: [
-    new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.optimize.UglifyJsPlugin(),
+    new webpack.optimize.OccurenceOrderPlugin()
   ],
 };


### PR DESCRIPTION
This fixes the global issue referenced here https://github.com/davidtheclark/react-aria-menubutton/issues/46. I also removed the minify portion if that is ok? I think it's nice to have the un-minified version so the end user can minify it in their pipeline.

I can also fix the NPMCDN build if you know how I would go about that?