### PR TITLE
Expose focus item

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,5 @@ module.exports = {
   MenuItem: require('./lib/MenuItem'),
   openMenu: externalStateControl.openMenu,
   closeMenu: externalStateControl.closeMenu,
+  focusItem: externalStateControl.focusItem,
 };

--- a/lib/externalStateControl.js
+++ b/lib/externalStateControl.js
@@ -22,9 +22,22 @@ function closeMenu(menuId, closeOptions) {
   manager.closeMenu(closeOptions);
 }
 
+function focusItem(menuId, index) {
+  var manager = registeredManagers[menuId];
+  if (!manager) throw new Error('Cannot close ' + errorCommon);
+  manager.focusGroup.activate();
+  if (manager.isOpen) {
+    var self = manager;
+    this.moveFocusTimer = setTimeout(function() {
+      self.focusItem(0)
+    }, 0);
+  }
+}
+
 module.exports = {
   registerManager: registerManager,
   unregisterManager: unregisterManager,
   openMenu: openMenu,
   closeMenu: closeMenu,
+  focusItem: focusItem,
 }

--- a/lib/externalStateControl.js
+++ b/lib/externalStateControl.js
@@ -24,12 +24,12 @@ function closeMenu(menuId, closeOptions) {
 
 function focusItem(menuId, index) {
   var manager = registeredManagers[menuId];
-  if (!manager) throw new Error('Cannot close ' + errorCommon);
+  if (!manager) throw new Error('Cannot focus item on ' + errorCommon);
   manager.focusGroup.activate();
   if (manager.isOpen) {
     var self = manager;
     this.moveFocusTimer = setTimeout(function() {
-      self.focusItem(0)
+      self.focusItem(index);
     }, 0);
   }
 }

--- a/test/externalStateControl-test.js
+++ b/test/externalStateControl-test.js
@@ -1,0 +1,23 @@
+var test = require('tape');
+var externalStateControl = require('../lib/externalStateControl');
+var createManager = require('../lib/createManager');
+var sinon = require('sinon');
+
+test('externalStateControl#focusItem', function(t) {
+  function mockManager(options) {
+    var manager = createManager(options);
+    manager.focusItem = sinon.stub();
+    manager.isOpen = true;
+
+    return manager;
+  }
+
+  var manager = mockManager();
+  externalStateControl.registerManager('test menu id', manager);
+  externalStateControl.focusItem('test menu id', 5);
+  setTimeout(function() {
+    t.ok(manager.focusItem.calledOnce);
+    t.ok(manager.focusItem.calledWith(5));
+    t.end();
+  }, 0);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -2,3 +2,4 @@ require('./Manager-test');
 require('./Button-test');
 require('./Menu-test');
 require('./MenuItem-test');
+require('./externalStateControl-test');


### PR DESCRIPTION
Expose FocusItem via `externalStateControl.focusItem`. This allows for writing logic to focus the first item in the menu when the menu is opened.