### PR TITLE
Detect active element in relative document

### DIFF
--- a/lib/createManager.js
+++ b/lib/createManager.js
@@ -105,9 +105,9 @@ var protoManager = {
 function handleBlur() {
   var self = this;
   self.blurTimer = setTimeout(function() {
-    var activeEl = document.activeElement;
     var buttonNode = ReactDOM.findDOMNode(self.button);
     var menuNode = ReactDOM.findDOMNode(self.menu);
+    var activeEl = buttonNode.ownerDocument.activeElement;
     if (buttonNode && activeEl === buttonNode) return;
     if (menuNode && menuNode.contains(activeEl)) return;
     if (self.isOpen) self.closeMenu({ focusButton: false });


### PR DESCRIPTION
We are using menubutton rendered in [react-frame-component](https://github.com/ryanseddon/react-frame-component). Referencing global `document` trips off the blur detection and item selection does not work. This PR fixes that by using relative `ownerDocument` reference which works in all cases.