### PR TITLE
Relax propTypes validation rules

### DIFF
--- a/lib/Button.js
+++ b/lib/Button.js
@@ -2,9 +2,12 @@ var React = require('react');
 var specialAssign = require('./specialAssign');
 
 var checkedProps = {
-  children: React.PropTypes.node.isRequired,
+  children: React.PropTypes.node,
   disabled: React.PropTypes.bool,
-  tag: React.PropTypes.string,
+  tag: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func,
+  ]),
 };
 
 module.exports = React.createClass({

--- a/lib/Menu.js
+++ b/lib/Menu.js
@@ -7,8 +7,11 @@ var checkedProps = {
   children: React.PropTypes.oneOfType([
     React.PropTypes.func,
     React.PropTypes.node,
-  ]).isRequired,
-  tag: React.PropTypes.string,
+  ]),
+  tag: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func,
+  ]),
 };
 
 module.exports = React.createClass({

--- a/lib/MenuItem.js
+++ b/lib/MenuItem.js
@@ -2,8 +2,11 @@ var React = require('react');
 var specialAssign = require('./specialAssign');
 
 var checkedProps = {
-  children: React.PropTypes.node.isRequired,
-  tag: React.PropTypes.string,
+  children: React.PropTypes.node,
+  tag: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func,
+  ]),
   text: React.PropTypes.string,
   value: React.PropTypes.any,
 };

--- a/lib/Wrapper.js
+++ b/lib/Wrapper.js
@@ -3,11 +3,14 @@ var createManager = require('./createManager');
 var specialAssign = require('./specialAssign');
 
 var checkedProps = {
-  children: React.PropTypes.node.isRequired,
+  children: React.PropTypes.node,
   onMenuToggle: React.PropTypes.func,
   onSelection: React.PropTypes.func.isRequired,
   closeOnSelection: React.PropTypes.bool,
-  tag: React.PropTypes.string,
+  tag: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func,
+  ]),
 };
 
 module.exports = React.createClass({


### PR DESCRIPTION
Make it possible to pass non-host components as `tag` prop. Also make `children`
non-required as non-host components passed as `tag` prop can supply needed
children themselves.

Thanks for this awesome lib! Really like how it works — minimal and functional and non-intrusive in regard to styling.