### PR TITLE
Disabled items should not be added to the focus group

### DIFF
--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -18,10 +18,12 @@ class AriaMenuButtonMenuItem extends React.Component {
   };
 
   componentDidMount() {
-    this.context.ambManager.addItem({
-      node: this.node,
-      text: this.props.text
-    });
+    if (!this.props.disabled) {
+      this.context.ambManager.addItem({
+        node: this.node,
+        text: this.props.text
+      });
+    }
   }
 
   handleKeyDown = event => {


### PR DESCRIPTION
When one or more MenuItems is disabled, it breaks the focus group functionality. Since a disabled item is not focusable, it is not possible to arrow past the item.
