### PR TITLE
Update for React 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aria-menubutton",
-  "version": "5.0.0",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "teeny-tap": "^0.2.0"
   },
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0",
-    "react-dom": "0.14.x || ^15.0.0"
+    "react": "0.14.x || ^15.0.0 || ^16.0.0",
+    "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
This allows react/react-dom v16 peerDependencies.

I didn't upgrade the dev version of `react` because that would require updating a lot of other dev dependencies; however, I did install it locally and run the demo successfully.