### PR TITLE
enable loose flag in babel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "babel": {
     "presets": [
       "react",
-      "env"
+      ["env", {"loose": true}]
     ],
     "plugins": [
       "transform-class-properties"


### PR DESCRIPTION
[Loose mode](https://babeljs.io/docs/en/babel-preset-env.html#loose) in babel creates a little bit smaller output than normal, at basically no cost. It saves a few kb of bundle size. After gzipping maybe a few hundred bytes.