### PR TITLE
Update description of value prop to allow Any type

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ All props are optional.
 
 **text** { String } *Required if child is an element*: If `text` has a value, its first letter will be the letter a user can type to navigate to that item.
 
-**value** { Object }: *Required if child is an element.* If `value` has a value, it will be passed to the `onSelection` handler when the `MenuItem` is selected.
+**value** { String | Boolean | Number | Object }: *Required if child is an element.* If `value` has a value, it will be passed to the `onSelection` handler when the `MenuItem` is selected.
 
 **tag** { String }: The HTML tag for this element. Default: `'span'`.
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ All props are optional.
 
 **text** { String } *Required if child is an element*: If `text` has a value, its first letter will be the letter a user can type to navigate to that item.
 
-**value** { String | Boolean | Number | Object }: *Required if child is an element.* If `value` has a value, it will be passed to the `onSelection` handler when the `MenuItem` is selected.
+**value** { Any }: *Required if child is an element.* If `value` has a value, it will be passed to the `onSelection` handler when the `MenuItem` is selected.
 
 **tag** { String }: The HTML tag for this element. Default: `'span'`.
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ All props are optional.
 
 **text** { String } *Required if child is an element*: If `text` has a value, its first letter will be the letter a user can type to navigate to that item.
 
-**value** { String | Boolean | Number }: *Required if child is an element.* If `value` has a value, it will be passed to the `onSelection` handler when the `MenuItem` is selected.
+**value** { Object }: *Required if child is an element.* If `value` has a value, it will be passed to the `onSelection` handler when the `MenuItem` is selected.
 
 **tag** { String }: The HTML tag for this element. Default: `'span'`.
 


### PR DESCRIPTION
This changes the description for the `value` prop to allow any type of object and not only `String | Boolean | Number` as there is nothing in the code preventing passing in any type of object.

This solves this issue https://github.com/davidtheclark/react-aria-menubutton/issues/90