### PR TITLE
chore(multi): Remove use of deprecated lifecycle methods

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -28,7 +28,7 @@ class AriaMenuButtonButton extends React.Component {
 
   static defaultProps = { tag: 'span' };
 
-  componentWillMount() {
+  componentDidMount() {
     this.context.ambManager.button = this;
   }
 

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -17,7 +17,7 @@ module.exports = class extends React.Component {
     ambManager: PropTypes.object.isRequired
   };
 
-  componentWillMount() {
+  componentDidMount() {
     this.context.ambManager.menu = this;
   }
 

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -20,13 +20,8 @@ class AriaMenuButtonWrapper extends React.Component {
     ambManager: PropTypes.object
   };
 
-  getChildContext() {
-    return {
-      ambManager: this.manager
-    };
-  }
-
-  componentWillMount() {
+  constructor(props) {
+    super(props);
     this.manager = createManager({
       onMenuToggle: this.props.onMenuToggle,
       onSelection: this.props.onSelection,
@@ -34,6 +29,12 @@ class AriaMenuButtonWrapper extends React.Component {
       closeOnBlur: this.props.closeOnBlur,
       id: this.props.id
     });
+  }
+
+  getChildContext() {
+    return {
+      ambManager: this.manager
+    };
   }
 
   render() {


### PR DESCRIPTION
React will deprecate a few lifecycle methods and `componentWillMount` is one of them:
https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path

Two possible ways to solve this:
 1. Replace `componentWillMount` with `UNSAFE_componentWillMount`
 2. Replace `componentWillMount` with `componentDidMount`

This PR removes use of deprecated `componentWillMount` method and replaces with `componentDidMount` + `constructor`