### PR TITLE
Add support for Home/End button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Latest
+
+- Bind `Home` key to jump to first item in the current menu.
+- Bind `End` key to jump to the last item in the current menu.
+
 ## 6.1.0
 
 - Add `closeOnBlur` prop.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ When focus is on the menu button or within the menu and you type a letter key, a
 
 So if you type `f` focus might arrive at `farm`; but then if you keep typing until you've typed `foo`, focus will skip ahead (past `farm` and `fit` and `fog`) to `foot`. This significantly improves your ability to type your way to your intended selection.
 
-This keyboard interaction (as well as the arrow keys) is enabled by the module [focus-group](//github.com/davidtheclark/focus-group). You can read more about the way letter navigation works [in that documentation](//github.com/davidtheclark/focus-group#string-searching).
+This keyboard interaction (as well as the <kbd>home</kbd>, <kbd>end</kbd>, and arrow keys) is enabled by the module [focus-group](//github.com/davidtheclark/focus-group). You can read more about the way letter navigation works [in that documentation](//github.com/davidtheclark/focus-group#string-searching).
 
 (In 3.x.x, when you typed a letter key focus moved to the next item in the menu (i.e. after the current focused item) that started with that letter, looping around to the front if if reached the end. This was more or less the suggested behavior from the ARIA suggestion and what I saw in jQuery UI. But I think the UX was insufficient, so when I separated out the letter navigation into the module [focus-group](//github.com/davidtheclark/focus-group), I tried to *improve letter navigation by more closely mimicking native `<select>` menus.)
 

--- a/src/createManager.js
+++ b/src/createManager.js
@@ -135,11 +135,23 @@ function handleSelection(value, event) {
 }
 
 function handleMenuKey(event) {
-  // "With focus on the drop-down menu, pressing Escape closes
-  // the menu and returns focus to the button.
-  if (this.isOpen && event.key === 'Escape') {
-    event.preventDefault();
-    this.closeMenu({ focusButton: true });
+  if (this.isOpen) {
+    switch (event.key) {
+      // With focus on the drop-down menu, pressing Escape closes
+      // the menu and returns focus to the button.
+      case 'Escape':
+        event.preventDefault();
+        this.closeMenu({ focusButton: true });
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.focusGroup.moveFocusToFirst();
+        break;
+      case 'End':
+        event.preventDefault();
+        this.focusGroup.moveFocusToLast();
+        break;
+    }
   }
 }
 


### PR DESCRIPTION
This adds additional keyboard navigation for the `Home` and `End` keys for moving focus to the first and last item in the menu respectively.

This is outlined in the WAI-ARIA specs [here](https://www.w3.org/TR/wai-aria-practices/examples/menubar/menubar-1/menubar-1.html#kbd_label).