### PR TITLE
Add `onBlurCapture` to capture tab events when using preact

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ const Example extends React.PureComponent {
 
 **closeOnBlur** { Boolean }: By default, it *does* automatically close. If `false`, the menu will *not* automatically close when it blurs. Default: `true`.
 
+**closeOnBlurEvent** { String }: The event name to use to trigger the `closeOnBlur` event. Useful when using [Preact](https://github.com/davidtheclark/react-aria-menubutton/issues/98) where the `onBlur` event does not propagate. Default: `onBlur`.
+
 **tag** { String }: The HTML tag for this element. Default: `'div'`.
 
 ### `Button`

--- a/src/Button.js
+++ b/src/Button.js
@@ -94,7 +94,7 @@ class AriaMenuButtonButton extends React.Component {
       delete reserved.disabled;
     }
     if (ambManager.options.closeOnBlur) {
-      buttonProps.onBlurCapture = ambManager.handleBlur;
+      buttonProps[ambManager.options.closeOnBlurEvent] = ambManager.handleBlur;
     }
     specialAssign(buttonProps, props, reserved);
 

--- a/src/Button.js
+++ b/src/Button.js
@@ -94,7 +94,7 @@ class AriaMenuButtonButton extends React.Component {
       delete reserved.disabled;
     }
     if (ambManager.options.closeOnBlur) {
-      buttonProps.onBlur = ambManager.handleBlur;
+      buttonProps.onBlurCapture = ambManager.handleBlur;
     }
     specialAssign(buttonProps, props, reserved);
 

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -83,7 +83,7 @@ module.exports = class extends React.Component {
     };
 
     if (ambManager.options.closeOnBlur) {
-      menuProps.onBlur = ambManager.handleBlur;
+      menuProps.onBlurCapture = ambManager.handleBlur;
     }
 
     specialAssign(menuProps, props, checkedProps);

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -83,7 +83,7 @@ module.exports = class extends React.Component {
     };
 
     if (ambManager.options.closeOnBlur) {
-      menuProps.onBlurCapture = ambManager.handleBlur;
+      menuProps[ambManager.options.closeOnBlurEvent] = ambManager.handleBlur;
     }
 
     specialAssign(menuProps, props, checkedProps);

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -32,6 +32,7 @@ class AriaMenuButtonWrapper extends React.Component {
       onSelection: this.props.onSelection,
       closeOnSelection: this.props.closeOnSelection,
       closeOnBlur: this.props.closeOnBlur,
+      closeOnBlurEvent: this.props.closeOnBlurEvent,
       id: this.props.id
     });
   }

--- a/src/__tests__/Button.test.js
+++ b/src/__tests__/Button.test.js
@@ -36,11 +36,25 @@ describe('<Button>', function() {
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
+  test('has onBlurCapture prop when closeOnBlur is true', function() {
+    const manager = createManager({ });
+    const shallowOptions = { context: { ambManager: manager } };
+    const wrapper = shallow(el(Button, null, ''), shallowOptions);
+    expect(shallowToJson(wrapper).props).toHaveProperty('onBlurCapture');
+  });
+
   test('no onBlur prop when closeOnBlur is false', function() {
     const manager = createManager({ closeOnBlur: false });
     const shallowOptions = { context: { ambManager: manager } };
     const wrapper = shallow(el(Button, null, ''), shallowOptions);
     expect(shallowToJson(wrapper).props).not.toHaveProperty('onBlur');
+  });
+
+  test('no onBlurCapture prop when closeOnBlur is false', function() {
+    const manager = createManager({ closeOnBlur: false });
+    const shallowOptions = { context: { ambManager: manager } };
+    const wrapper = shallow(el(Button, null, ''), shallowOptions);
+    expect(shallowToJson(wrapper).props).not.toHaveProperty('onBlurCapture');
   });
 
   test('DOM with all possible props and element child', function() {

--- a/src/__tests__/Button.test.js
+++ b/src/__tests__/Button.test.js
@@ -36,8 +36,8 @@ describe('<Button>', function() {
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 
-  test('has onBlurCapture prop when closeOnBlur is true', function() {
-    const manager = createManager({ });
+  test('has closeOnBlurEvent prop when closeOnBlur is true and prop name is passed', function() {
+    const manager = createManager({ closeOnBlur: true, closeOnBlurEvent: "onBlurCapture" });
     const shallowOptions = { context: { ambManager: manager } };
     const wrapper = shallow(el(Button, null, ''), shallowOptions);
     expect(shallowToJson(wrapper).props).toHaveProperty('onBlurCapture');
@@ -50,8 +50,8 @@ describe('<Button>', function() {
     expect(shallowToJson(wrapper).props).not.toHaveProperty('onBlur');
   });
 
-  test('no onBlurCapture prop when closeOnBlur is false', function() {
-    const manager = createManager({ closeOnBlur: false });
+  test('no closeOnBlurEvent prop when closeOnBlur is false', function() {
+    const manager = createManager({ closeOnBlur: false, closeOnBlurEvent: "onBlurCapture" });
     const shallowOptions = { context: { ambManager: manager } };
     const wrapper = shallow(el(Button, null, ''), shallowOptions);
     expect(shallowToJson(wrapper).props).not.toHaveProperty('onBlurCapture');

--- a/src/__tests__/Menu.test.js
+++ b/src/__tests__/Menu.test.js
@@ -36,8 +36,8 @@ describe('<Menu>', function() {
     expect(shallowToJson(wrapper).props).not.toHaveProperty('onBlur');
   });
 
-  test('no onBlurCapture prop when closeOnBlur is false', function() {
-    const ambManager = createManager({ closeOnBlur: false });
+  test('no closeOnBlurEvent prop when closeOnBlur is false', function() {
+    const ambManager = createManager({ closeOnBlur: false, closeOnBlurEvent: 'onBlurCapture' });
     ambManager.isOpen = true;
     const shallowOptions = { context: { ambManager: ambManager } };
     const menuEl = el(Menu, null, el('div', null, 'foo'));
@@ -45,8 +45,17 @@ describe('<Menu>', function() {
     expect(shallowToJson(wrapper).props).not.toHaveProperty('onBlurCapture');
   });
 
-  test('has onBlurCapture prop when closeOnBlur is true', function() {
+  test('has onBlur prop when closeOnBlur is true', function() {
     const ambManager = createManager({ });
+    ambManager.isOpen = true;
+    const shallowOptions = { context: { ambManager: ambManager } };
+    const menuEl = el(Menu, null, el('div', null, 'foo'));
+    const wrapper = shallow(menuEl, shallowOptions);
+    expect(shallowToJson(wrapper).props).toHaveProperty('onBlur');
+  });
+
+  test('has closeOnBlurEvent prop when closeOnBlur is true and closeOnBlurEvent is set', function() {
+    const ambManager = createManager({ closeOnBlurEvent: 'onBlurCapture' });
     ambManager.isOpen = true;
     const shallowOptions = { context: { ambManager: ambManager } };
     const menuEl = el(Menu, null, el('div', null, 'foo'));

--- a/src/__tests__/Menu.test.js
+++ b/src/__tests__/Menu.test.js
@@ -36,6 +36,24 @@ describe('<Menu>', function() {
     expect(shallowToJson(wrapper).props).not.toHaveProperty('onBlur');
   });
 
+  test('no onBlurCapture prop when closeOnBlur is false', function() {
+    const ambManager = createManager({ closeOnBlur: false });
+    ambManager.isOpen = true;
+    const shallowOptions = { context: { ambManager: ambManager } };
+    const menuEl = el(Menu, null, el('div', null, 'foo'));
+    const wrapper = shallow(menuEl, shallowOptions);
+    expect(shallowToJson(wrapper).props).not.toHaveProperty('onBlurCapture');
+  });
+
+  test('has onBlurCapture prop when closeOnBlur is true', function() {
+    const ambManager = createManager({ });
+    ambManager.isOpen = true;
+    const shallowOptions = { context: { ambManager: ambManager } };
+    const menuEl = el(Menu, null, el('div', null, 'foo'));
+    const wrapper = shallow(menuEl, shallowOptions);
+    expect(shallowToJson(wrapper).props).toHaveProperty('onBlurCapture');
+  });
+
   test('open Menu DOM with only required props and element child', function() {
     ambManager.isOpen = true;
     const menuEl = el(Menu, null, el('div', null, el('div', null, 'foo')));

--- a/src/__tests__/createManager.test.js
+++ b/src/__tests__/createManager.test.js
@@ -41,6 +41,7 @@ describe('createManager', function() {
     expect(manager.isOpen).toBe(false);
     expect(manager.options.closeOnSelection).toBeTruthy();
     expect(manager.options.closeOnBlur).toBeTruthy();
+    expect(manager.options.closeOnBlurEvent).toBe("onBlur");
   });
 
   it('Manager#update', function() {

--- a/src/__tests__/helpers/createMockManager.js
+++ b/src/__tests__/helpers/createMockManager.js
@@ -16,6 +16,7 @@ module.exports = function() {
     addItem: jest.fn(),
     options: {
       closeOnBlur: true,
+      closeOnBlurEvent: "onBlur",
       closeOnSelection: true
     }
   };

--- a/src/createManager.js
+++ b/src/createManager.js
@@ -19,6 +19,10 @@ const protoManager = {
       this.options.closeOnBlur = true;
     }
 
+    if (typeof this.options.closeOnBlurEvent === 'undefined') {
+      this.options.closeOnBlurEvent = "onBlur";
+    }
+
     if (this.options.id) {
       externalStateControl.registerManager(this.options.id, this);
     }


### PR DESCRIPTION
Related #98 .

Although the code is correct for pure React components, when using certain versions of Preact (https://github.com/preactjs/preact/issues/1621) the blur event does not trigger correctly unless focus is directly on the `role=menu` element.

This fix should address the issue for Preact, whilst keeping functionality of React unchanged.