### PR TITLE
Only close the menu in `handleTap` when `closeOnSelection === true`

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -59,7 +59,9 @@ module.exports = class extends React.Component {
       )
     )
       return;
-    this.context.ambManager.closeMenu();
+    if(!this.context.ambManager.options.closeOnSelection) {
+      this.context.ambManager.closeMenu();
+    }
   };
 
   render() {

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -59,7 +59,7 @@ module.exports = class extends React.Component {
       )
     )
       return;
-    if(!this.context.ambManager.options.closeOnSelection) {
+    if(this.context.ambManager.options.closeOnSelection) {
       this.context.ambManager.closeMenu();
     }
   };


### PR DESCRIPTION
There was an issue that `this.context.ambManager.closeMenu();` was being called in the `handleTap` function even when `closeOnSelection` was `false`. This causes weird behavior where the menu stays open on desktop but closes on mobile.

If `closeOnSelection` is `false`, then the behavior should be consistent across devices.