### PR TITLE
Prevent behavior of a Button element when the space key is pressed

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -69,6 +69,10 @@ class AriaMenuButtonButton extends React.Component {
     this.context.ambManager.toggleMenu({}, { focusMenu: false });
   };
 
+  handleKeyUp = (event) => {
+    event.preventDefault();
+  }
+
   render() {
     const props = this.props;
     const ambManager = this.context.ambManager;
@@ -82,6 +86,7 @@ class AriaMenuButtonButton extends React.Component {
       'aria-expanded': ambManager.isOpen,
       'aria-disabled': props.disabled,
       onKeyDown: this.handleKeyDown,
+      onKeyUp: this.handleKeyUp,
       onClick: this.handleClick
     };
 

--- a/src/__tests__/Button.test.js
+++ b/src/__tests__/Button.test.js
@@ -120,6 +120,13 @@ describe('<Button>', function() {
     expect(ambManager.toggleMenu).toHaveBeenCalledTimes(1);
   });
 
+  test('prevent behavior of a Button element when the space key is pressed', function() {
+    const wrapper = shallow(el(Button, null, 'foo'), shallowOptions);
+    wrapper.simulate('keyUp', spaceEvent);
+
+    expect(spaceEvent.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
   test('escape key', function() {
     const wrapper = shallow(el(Button, null, 'foo'), shallowOptions);
     wrapper.simulate('keyDown', escapeEvent);

--- a/src/__tests__/__snapshots__/Button.test.js.snap
+++ b/src/__tests__/__snapshots__/Button.test.js.snap
@@ -11,6 +11,7 @@ exports[`<Button> DOM with all possible props and element child 1`] = `
   id="foo"
   onClick={[Function]}
   onKeyDown={[Function]}
+  onKeyUp={[Function]}
   role="button"
   style={
     Object {
@@ -31,6 +32,7 @@ exports[`<Button> DOM with only required props and text child 1`] = `
   aria-haspopup={true}
   onClick={[Function]}
   onKeyDown={[Function]}
+  onKeyUp={[Function]}
   role="button"
   tabIndex="0"
 >


### PR DESCRIPTION
related: # 107

The space key in the Button element has a behavior similar to the keyUp event.
This will fire an unexpected click event in some browsers.
This PR prevents keyUp events on the Button component and avoids malfunctions in browsers such as Firefox.