### PR TITLE
check for presence of self.button in handleBlur method

### DIFF
--- a/src/createManager.js
+++ b/src/createManager.js
@@ -114,6 +114,7 @@ const protoManager = {
 function handleBlur() {
   const self = this;
   self.blurTimer = setTimeout(function() {
+    if (!self.button) return;
     const buttonNode = self.button.ref.current;
     if (!buttonNode) return;
     const activeEl = buttonNode.ownerDocument.activeElement;


### PR DESCRIPTION
We recently upgraded from version 5.1 to version 7.0.0 and we're now periodically getting a type error on this line: https://github.com/davidtheclark/react-aria-menubutton/blob/f05b24f0b0f715ab04fe5dfeeef88bf43d8b1844/src/createManager.js#L117. I haven't been able to reliably reproduce this error, but I see https://github.com/davidtheclark/react-aria-menubutton/pull/113 removed `ReactDOM.findDOMNode` so the `createManager.js`'s `handleBlur()` method is failing a check it used to make. 

Before, if `self.button` was `null`, `ReactDOM.findDOMNode(null)` would return `null` and the `setTimeout` method would gracefully end, but now it tries to access `null.ref.current` and results in an error. Would it be possible to add a check for the presence of `self.button`, and `return` if it's not there?