### PR TITLE
Fix ref prop type

### DIFF
--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -3,6 +3,6 @@ const PropTypes = require("prop-types");
 module.exports = {
   refType: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.elementType })
+    PropTypes.shape({ current: PropTypes.oneOfType([PropTypes.elementType, PropTypes.instanceOf(Element)]) })
   ])
 };


### PR DESCRIPTION
Fixes this error when passing a (forwarded) `ref` prop into `Button`:

```
Warning: Failed prop type: Invalid prop `forwardedRef` supplied to `AriaMenuButtonButton`.
    in AriaMenuButtonButton (created by Context.Consumer)
```

![image](https://user-images.githubusercontent.com/921609/98240538-77f89280-1f61-11eb-9da8-8915fc0818b7.png)
