### PR TITLE
Fix onSelection bug

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -15,19 +15,27 @@ const checkedProps = {
   tag: PropTypes.string
 };
 
+const managerOptionsFromProps = (props) => {
+  return {
+    onMenuToggle: props.onMenuToggle,
+    onSelection: props.onSelection,
+    closeOnSelection: props.closeOnSelection,
+    closeOnBlur: props.closeOnBlur,
+    id: props.id
+  }
+}
+
 class AriaMenuButtonWrapper extends React.Component {
   static propTypes = checkedProps;
   static defaultProps = { tag: 'div' };
 
   constructor(props) {
     super(props);
-    this.manager = createManager({
-      onMenuToggle: this.props.onMenuToggle,
-      onSelection: this.props.onSelection,
-      closeOnSelection: this.props.closeOnSelection,
-      closeOnBlur: this.props.closeOnBlur,
-      id: this.props.id
-    });
+    this.manager = createManager(managerOptionsFromProps(props));
+  }
+
+  componentDidUpdate() {
+    this.manager.updateOptions(managerOptionsFromProps(this.props))
   }
 
   render() {

--- a/src/createManager.js
+++ b/src/createManager.js
@@ -8,19 +8,7 @@ const focusGroupOptions = {
 
 const protoManager = {
   init(options) {
-    this.options = options || {};
-
-    if (typeof this.options.closeOnSelection === 'undefined') {
-      this.options.closeOnSelection = true;
-    }
-
-    if (typeof this.options.closeOnBlur === 'undefined') {
-      this.options.closeOnBlur = true;
-    }
-
-    if (this.options.id) {
-      externalStateControl.registerManager(this.options.id, this);
-    }
+    this.updateOptions(options);
 
     this.handleBlur = handleBlur.bind(this);
     this.handleSelection = handleSelection.bind(this);
@@ -40,6 +28,29 @@ const protoManager = {
 
     // State trackers
     this.isOpen = false;
+  },
+
+  updateOptions(options) {
+    const oldOptions = this.options;
+
+    this.options = options || this.options || {};
+
+    if (typeof this.options.closeOnSelection === 'undefined') {
+      this.options.closeOnSelection = true;
+    }
+
+    if (typeof this.options.closeOnBlur === 'undefined') {
+      this.options.closeOnBlur = true;
+    }
+
+    if (this.options.id) {
+      externalStateControl.registerManager(this.options.id, this);
+    }
+
+    if (oldOptions && oldOptions.id && oldOptions.id !== this.options.id) {
+      externalStateControl.unregisterManager(this.options.id, this);
+    }
+
   },
 
   focusItem(index) {


### PR DESCRIPTION
Fixes https://github.com/davidtheclark/react-aria-menubutton/issues/142

Props in react can change over time, so they should not be saved when a component first mounts and then never updated. This causes issues when you, say, have a dynamic callback in `onSelection` that changes over time. Without this change, this library was calling the old/outdated callback instead of the most recent one.

This is a quick and easy fix, though I imagine a better fix would involve rewriting more of the code here. I don't see any reason for this to be problematic though. I've used this in my own project where I observed the bug and this does resolve it.

This PR includes `/dist` which is built via `npm run prePublishOnly && git add -f ./dist/`, which we wouldn't include before merging this PR. But in order to use this fork/branch directly in `package.json` I believe this was necessary for now.

For anyone else wanting to use this fork to fix https://github.com/davidtheclark/react-aria-menubutton/issues/142 before it is merged, you can use this line in your `package.json`:

```json
"react-aria-menubutton": "https://github.com/MercuryTechnologies/react-aria-menubutton.git#fixOnSelectionBug",
```